### PR TITLE
Remove rogue purple

### DIFF
--- a/client/knowledge_base_search/src/App.scss
+++ b/client/knowledge_base_search/src/App.scss
@@ -86,7 +86,7 @@ a {
 }
 
 .base--button.base--button_fill {
-  &:visited, &:hover, &:active, &:focus {
+  &, &:visited, &:hover, &:active, &:focus {
     background-color: color('teal', 80);
     border-color: color('teal', 80);
   }

--- a/client/knowledge_base_search/src/containers/SearchContainer/styles.scss
+++ b/client/knowledge_base_search/src/containers/SearchContainer/styles.scss
@@ -141,7 +141,8 @@
     padding-right: 1.7rem;
 
     &:focus {
-      outline-color: color('white', 10);
+      border-color: color('white', 10);
+      outline: none;
     }
   }
 }


### PR DESCRIPTION
There was purple showing up in FF in two places:
- the 'Start free in Bluemix' button
- As a border when the questions dropdown was focussed.

This fixes that back to the correct colors.